### PR TITLE
Adding International Format Method to PhoneNumber Class

### DIFF
--- a/lib/src/models/phone_number.dart
+++ b/lib/src/models/phone_number.dart
@@ -66,6 +66,10 @@ class PhoneNumber {
   String getFormattedNsn({IsoCode? isoCode}) =>
       PhoneNumberFormatter.formatNsn(nsn, isoCode ?? this.isoCode);
 
+  /// formats the number using the International Format.
+  String getFormattedIntl() =>
+      ('+' + countryCode + ' ' + getFormattedNsn()).trim();
+
   //
   //  Validation
   //


### PR DESCRIPTION
Adds a `getFormattedIntl()` method to `PhoneNumber` class

Resolves Issue #28 