### PR TITLE
Issue #46 (Wrong result from local number) fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ build/
 
 # Directory created by dartdoc
 doc/api/
+
+# macOS files
+.DS_Store
+

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -71,4 +71,9 @@ void main(List<String> arguments) {
   two - 1 == one;
   final another = one + 2;
   print('$another == $three');
+
+  final usLocalNumber = PhoneNumber.parse("(707) 555-1854", callerCountry: IsoCode.US);
+  final usIntrnNumber = PhoneNumber.parse("+1 (707) 555-1854");
+
+  print("US local number $usLocalNumber equals US international number $usIntrnNumber - ${usLocalNumber == usIntrnNumber}"); // true
 }

--- a/lib/src/metadata/metadata_matcher.dart
+++ b/lib/src/metadata/metadata_matcher.dart
@@ -4,11 +4,11 @@ import 'package:phone_numbers_parser/src/parsers/_validator.dart';
 import 'models/phone_metadata.dart';
 
 abstract class MetadataMatcher {
-  static PhoneMetadata getMatchUsingPatterns(
+
+  static PhoneMetadata? getMatchUsingPatternsStrict(
     String nationalNumber,
-    List<PhoneMetadata> potentialFits,
+    List<PhoneMetadata> potentialFits
   ) {
-    if (potentialFits.length == 1) return potentialFits[0];
     potentialFits = reducePotentialMetadatasFits(nationalNumber, potentialFits);
     for (var fit in potentialFits) {
       final isValidForIso = Validator.validateWithPattern(
@@ -17,7 +17,14 @@ abstract class MetadataMatcher {
         return fit;
       }
     }
-    return potentialFits[0];
+    return null;
+  }
+
+  static PhoneMetadata getMatchUsingPatterns(
+    String nationalNumber,
+    List<PhoneMetadata> potentialFits,
+  ) {
+    return getMatchUsingPatternsStrict(nationalNumber, potentialFits) ?? potentialFits[0];
   }
 
   /// Given a list of metadata fits, return the ones that fit a national number


### PR DESCRIPTION
Hello,

These changes will fix the [Wrong result obtained from local number #46](https://github.com/cedvdb/phone_numbers_parser/issues/46) issue. 

After applying the changes, the following local US phone numbers are parsed successfully: 
```
(888) 555-5512
(408) 555-5270
(707) 555-1854
```

All the interfaces are kept, as well as all tests are valid. The major problem is that the code of the fix is a bit clumsy. At best, `CountryCodeParser.extractCountryCode` should return an optional, as PhoneParser._findDestinationMetadata itself.

I consciously stopped on as it is, not to spread the changes over the whole project.

