### PR TITLE
[FIX} mobile brazilian numbers are 11 digits and fixedLines are 10

### DIFF
--- a/lib/src/metadata/generated/metadata_lengths_by_iso_code.dart
+++ b/lib/src/metadata/generated/metadata_lengths_by_iso_code.dart
@@ -154,7 +154,7 @@ const metadataLenghtsByIsoCode = {
   ),
   IsoCode.BR: PhoneMetadataLengths(
     general: [],
-    mobile: [10, 11],
+    mobile: [11],
     fixedLine: [10],
   ),
   IsoCode.BS: PhoneMetadataLengths(

--- a/lib/src/metadata/generated/metadata_patterns_by_iso_code.dart
+++ b/lib/src/metadata/generated/metadata_patterns_by_iso_code.dart
@@ -243,10 +243,8 @@ const metadataPatternsByIsoCode = {
     nationalPrefixTransformRule: r"$2",
     general:
         r"(?:[1-46-9]\d\d|5(?:[0-46-9]\d|5[0-46-9]))\d{8}|[1-9]\d{9}|[3589]\d{8}|[34]\d{7}",
-    mobile:
-        r"(?:[14689][1-9]|2[12478]|3[1-578]|5[13-5]|7[13-579])(?:7|9\d)\d{7}",
-    fixedLine:
-        r"(?:[14689][1-9]|2[12478]|3[1-578]|5[13-5]|7[13-579])[2-5]\d{7}",
+    mobile: r"\d{11}",
+    fixedLine: r"\d{10}",
   ),
   IsoCode.BS: PhoneMetadataPatterns(
     nationalPrefixForParsing: r"([3-8]\d{6})$|1",

--- a/test/internal/_validator_test.dart
+++ b/test/internal/_validator_test.dart
@@ -5,6 +5,25 @@ import 'package:test/test.dart';
 void main() {
   group('_Validator', () {
     group('ValidateWithLength()', () {
+      test('BR', () {
+        final beValidMobilePhone = '31975228038';
+        final beInvalidMobilePhone = '3175228038';
+        expect(
+          Validator.validateWithLength(
+            IsoCode.BR,
+            beValidMobilePhone,
+            PhoneNumberType.mobile,
+          ),
+          isTrue,
+        );
+        expect(
+            Validator.validateWithLength(
+              IsoCode.BR,
+              beInvalidMobilePhone,
+              PhoneNumberType.mobile,
+            ),
+            isFalse);
+      });
       test('BE', () {
         final beValidMobilePhone = '479554265';
         final beInvalidMobilePhone = '4795542650';
@@ -79,6 +98,18 @@ void main() {
     });
 
     group('ValidateWithPattern()', () {
+      test('BR', () {
+        final validMobileBR = '31972727272';
+        final invalidMobileBR = '3172727272';
+        expect(
+            Validator.validateWithPattern(
+                IsoCode.BR, validMobileBR, PhoneNumberType.mobile),
+            isTrue);
+        expect(
+            Validator.validateWithPattern(
+                IsoCode.BR, invalidMobileBR, PhoneNumberType.mobile),
+            isFalse);
+      });
       test('BE', () {
         final validMobileBE = '479889855';
         final validFixedBE = '64223344';


### PR DESCRIPTION
I only update mobile and fixed lines, help me understand if I'm missing something about what you wanted.
Usually Brazilian phones are defined this way
+55 31 9 1234-1234
National Code +55
Followed by state 31
Followed by 9 numbers and 8 numbers if it is a fixed line

![Uploading image.png…]()
