### PR TITLE
Bugfix /  Argentinian transformRule mismatch $2 15-$3-$4

### DIFF
--- a/lib/src/parsers/_national_number_parser.dart
+++ b/lib/src/parsers/_national_number_parser.dart
@@ -73,9 +73,7 @@ abstract class NationalNumberParser {
 
     var transformed = transformRule;
     bool shouldContinueLoop(int i) =>
-        match.groupCount >= i &&
-        match.group(i) != null &&
-        transformed.contains('\$$i');
+        match.groupCount >= i && match.group(i) != null;
     for (var i = 1; shouldContinueLoop(i); i++) {
       transformed = transformed.replaceFirst('\$$i', match.group(i)!);
     }

--- a/test/phone_number_test.dart
+++ b/test/phone_number_test.dart
@@ -407,4 +407,51 @@ void main() {
       expect(zero.isSequentialTo(two), isFalse);
     });
   });
+  group(
+      'format national phone number if transformRule does not start with \$1. example: (\$2 15-\$3-\$4)(AR)',
+      () {
+    test('should return the formated phone number not the transformRule string',
+        () {
+      String format(String phoneNumber) =>
+          PhoneNumber.parse(phoneNumber, destinationCountry: IsoCode.AR)
+              .formatNsn();
+      var testNumber = '';
+      expect(format(testNumber), equals(''));
+      testNumber = '5';
+      expect(format(testNumber), equals('5'));
+      testNumber = '54';
+      expect(format(testNumber), equals('54'));
+      testNumber = '549';
+      expect(format(testNumber), equals('549'));
+      testNumber = '5492';
+      expect(format(testNumber), equals('5492'));
+      testNumber = '54926';
+      expect(format(testNumber), equals('54926'));
+      testNumber = '549261';
+      expect(format(testNumber), equals('549261'));
+      testNumber = '5492615';
+      expect(format(testNumber), equals('5492615'));
+      testNumber = '54926153';
+      expect(format(testNumber), equals('54926153'));
+      testNumber = '549261532';
+      expect(format(testNumber), equals('549261532'));
+      testNumber = '5492615325';
+      expect(format(testNumber), equals('5492615325'));
+
+      testNumber = '54926153256';
+      expect(format(testNumber), equals('54926153256'));
+      testNumber = '549261532565';
+      expect(format(testNumber), equals('549261532565'));
+      testNumber = '5492615325656';
+      expect(format(testNumber), equals('261 15-532-5656'));
+      testNumber = '+5492615325656';
+      expect(format(testNumber), equals('261 15-532-5656'));
+      testNumber = '54 9 261-5325 656';
+      expect(format(testNumber), equals('261 15-532-5656'));
+      testNumber = '54-9-261-5325-656';
+      expect(format(testNumber), equals('261 15-532-5656'));
+      testNumber = '54.9.261.5325.656';
+      expect(format(testNumber), equals('261 15-532-5656'));
+    });
+  });
 }

--- a/test/phone_number_test.dart
+++ b/test/phone_number_test.dart
@@ -410,8 +410,7 @@ void main() {
   group(
       'format national phone number if transformRule does not start with \$1. example: (\$2 15-\$3-\$4)(AR)',
       () {
-    test('should return the formated phone number not the transformRule string',
-        () {
+    test('should format argentinian phone numbers', () {
       String format(String phoneNumber) =>
           PhoneNumber.parse(phoneNumber, destinationCountry: IsoCode.AR)
               .formatNsn();


### PR DESCRIPTION
Hello, I found a bug while using  phone_form_field: ^9.1.0 while trying to input an Argentinian phone number:
<img width="350" alt="Screenshot 2024-11-08 at 18 40 54" src="https://github.com/user-attachments/assets/b3add71d-c3b2-408d-a5f2-a3ce01c01ffc">

I've got the same result with running phone_numbers_parser locally:
<img width="651" alt="Screenshot 2024-11-08 at 22 37 34" src="https://github.com/user-attachments/assets/526d7f63-7764-4d7c-9b00-fce484125eaf">

I have also checked libphonenumber and it seems to woks fine:
<img width="554" alt="Screenshot 2024-11-08 at 23 48 32" src="https://github.com/user-attachments/assets/eae35e7f-1b85-4735-ade7-c783db3e5d8e">

The thing is that the transformRule starts with $2 (ex: $2 15-$3-$4) that will stop the loop and return the string without formatting it properly. I removed the contain index check of the transform rule in order to support the rules that does not start necessarily with 1, and it seems to work fine. If there is a better solution for this problem let me know an i can look into it and update the pr, thanks. Cheers! 

<img width="277" alt="Screenshot 2024-11-08 at 23 57 21" src="https://github.com/user-attachments/assets/b8fb6349-11d7-4408-bda5-c05252333b2b">
