### PR TITLE
Add auto publish action #73

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,12 @@
+name: Publish to pub.dev
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  publish:
+    permissions:
+      id-token: write # Required for authentication using OIDC
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1

--- a/.github/workflows/update_metadata.yml
+++ b/.github/workflows/update_metadata.yml
@@ -1,5 +1,4 @@
-name: Update Metadata
-
+name: Update Metadata and Publish
 on:
   schedule:
     # At 12:00 AM, on day 1 of each month
@@ -7,31 +6,49 @@ on:
   workflow_dispatch:
 
 jobs:
-  generate:
+  update-and-publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - uses: dart-lang/setup-dart@v1
-
+      
       - name: Install dependencies
         run: dart pub get
-
+      
       - name: Fetch LibPhoneNumber Metadata
         run: curl -o resources/data_sources/PhoneNumberMetadata.xml https://raw.githubusercontent.com/google/libphonenumber/master/resources/PhoneNumberMetadata.xml
-
+      
       - name: Process Metadata
         run: dart resources/data_sources/convert_metadata.dart
-
+      
       - name: Generate Files
         run: |
           dart pub get
           dart resources/generate_files.dart && dart format lib/src && dart fix --apply
-
+      
+      - name: Update Version
+        run: |
+          # Read the current version from pubspec.yaml
+          CURRENT_VERSION=$(grep 'version:' pubspec.yaml | sed 's/version: //')
+          # Increment the patch version
+          NEW_VERSION=$(echo $CURRENT_VERSION | awk -F. '{$NF = $NF + 1;} 1' | sed 's/ /./g')
+          # Update pubspec.yaml with new version
+          sed -i "s/version: $CURRENT_VERSION/version: $NEW_VERSION/" pubspec.yaml
+      
       - name: Commit and Push Updated Files
         run: |
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
           git add .
-          git commit -m "Update Metadata" || echo "Nothing to commit!"
+          git commit -m "Update Metadata and bump version" || echo "Nothing to commit!"
           git push
+      
+      - name: Publish to pub.dev
+        env:
+          PUB_CREDENTIALS: ${{ secrets.PUB_CREDENTIALS }}
+        run: |
+          # Create credentials file
+          mkdir -p ~/.pub-cache
+          echo "$PUB_CREDENTIALS" > ~/.pub-cache/credentials.json
+          # Publish package
+          dart pub publish --force

--- a/.github/workflows/update_metadata.yml
+++ b/.github/workflows/update_metadata.yml
@@ -32,12 +32,11 @@ jobs:
       
       - name: Update Version and Create Tag
         run: |
-          # Read the current version from pubspec.yaml
-          CURRENT_VERSION=$(grep 'version:' pubspec.yaml | sed 's/version: //')
-          # Increment the patch version
-          NEW_VERSION=$(echo $CURRENT_VERSION | awk -F. '{$NF = $NF + 1;} 1' | sed 's/ /./g')
-          # Update pubspec.yaml with new version
-          sed -i "s/version: $CURRENT_VERSION/version: $NEW_VERSION/" pubspec.yaml
+          # Bump version
+          dart pub bump patch
+          
+          # Get the new version for the commit message
+          NEW_VERSION=$(grep 'version:' pubspec.yaml | sed 's/version: //')
           
           # Commit and push changes
           git config --global user.name "GitHub Actions"

--- a/.github/workflows/update_metadata.yml
+++ b/.github/workflows/update_metadata.yml
@@ -1,4 +1,5 @@
-name: Update Metadata and Publish
+name: Update Metadata
+
 on:
   schedule:
     # At 12:00 AM, on day 1 of each month
@@ -6,10 +7,13 @@ on:
   workflow_dispatch:
 
 jobs:
-  update-and-publish:
+  update:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Needed for git describe
+      
       - uses: dart-lang/setup-dart@v1
       
       - name: Install dependencies
@@ -26,7 +30,7 @@ jobs:
           dart pub get
           dart resources/generate_files.dart && dart format lib/src && dart fix --apply
       
-      - name: Update Version
+      - name: Update Version and Create Tag
         run: |
           # Read the current version from pubspec.yaml
           CURRENT_VERSION=$(grep 'version:' pubspec.yaml | sed 's/version: //')
@@ -34,21 +38,14 @@ jobs:
           NEW_VERSION=$(echo $CURRENT_VERSION | awk -F. '{$NF = $NF + 1;} 1' | sed 's/ /./g')
           # Update pubspec.yaml with new version
           sed -i "s/version: $CURRENT_VERSION/version: $NEW_VERSION/" pubspec.yaml
-      
-      - name: Commit and Push Updated Files
-        run: |
+          
+          # Commit and push changes
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
           git add .
-          git commit -m "Update Metadata and bump version" || echo "Nothing to commit!"
+          git commit -m "Update Metadata and bump version to $NEW_VERSION" || exit 0
           git push
-      
-      - name: Publish to pub.dev
-        env:
-          PUB_CREDENTIALS: ${{ secrets.PUB_CREDENTIALS }}
-        run: |
-          # Create credentials file
-          mkdir -p ~/.pub-cache
-          echo "$PUB_CREDENTIALS" > ~/.pub-cache/credentials.json
-          # Publish package
-          dart pub publish --force
+          
+          # Create and push tag
+          git tag "v$NEW_VERSION"
+          git push origin "v$NEW_VERSION"


### PR DESCRIPTION
# GitHub Actions Workflows #73

These workflows automatically update your package's phone number metadata and publish to pub.dev.

## Metadata Update Workflow (`metadata-update.yml`)

This workflow runs on the 1st of each month and:
- Downloads new phone number metadata from Google's libphonenumber
- Updates package files with new data
- Increases package version number
- Creates a git tag with new version (e.g. 'v1.2.3')
- Pushes changes to GitHub

## Publish Workflow (`publish.yml`)

This workflow automatically triggers when a version tag is pushed and:
- Starts when metadata workflow creates a new version tag
- Uses Dart's official process to publish to pub.dev 
- Uses secure OIDC authentication - no manual tokens needed

## Setup Required (for owner)

1. Add both workflow files to `.github/workflows/`
2. Enable GitHub Actions permissions:
  - Go to repository Settings → Actions → General
  - Enable "Read and write permissions"
  - Enable "Allow GitHub Actions to create and approve pull requests"
3. Verify pub.dev publisher status:
  - Login to pub.dev
  - Verify publishing rights for package
  - Ensure Google Account is verified

The workflows will then automatically update and publish the package monthly.